### PR TITLE
Label image to point clouds and mesh

### DIFF
--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -84,7 +84,7 @@ def label_tif_to_pc_directory(path: str , save_dir: str, num_points: int, min_si
                                         else:
                                               valid.append(False)      
                             else:
-                                  for j in range(len(min_size)):
+                                  for j in range(len(binary_image.shape)):
                                               valid.append(True)
                                                     
                             if False not in valid:               

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -69,9 +69,9 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
                     mesh_obj = trimesh.Trimesh(
                         vertices=vertices, faces=faces, process=False
                     )
-                    mesh_file = mesh_save_dir + name + str(l) 
-                    mesh_obj.export(mesh_file + ".off") 
-                    data = read_off(mesh_file)
+                    mesh_file = name + str(l) 
+                    mesh_obj.export(os.path.join(mesh_save_dir, mesh_file) + ".off") 
+                    data = read_off(os.path.join(mesh_save_dir, mesh_file))
                     points = sample_points(data=data, num=num_points).numpy()
                     mesh_data.append(mesh_obj) 
                     points_data.append(points)

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -67,11 +67,11 @@ def label_tif_to_pc_directory(path: str , save_dir: str, num_points: int):
                 clear_lbl_img = clear_border(lbl_img)
                 print('cleared borders')
                 name = os.path.basename(os.path.splitext(path)[0])
-                nthreads = os.cpu_count()
+                nthreads = os.cpu_count() - 1
 
                 with concurrent.futures.ThreadPoolExecutor(max_workers = nthreads) as executor:
                     futures = []
-                    for l in (set(np.unique(clear_lbl_img)) - set([0])):
+                    for l in tqdm(set(np.unique(clear_lbl_img)) - set([0])):
                         futures.append(executor.submit(get_current_label, clear_lbl_img, l))
                     for future in concurrent.futures.as_completed(futures):
                         binary_image = future.result()    

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -70,7 +70,7 @@ def label_tif_to_pc_directory(path: str , save_dir: str, num_points: int):
                 with concurrent.futures.ThreadPoolExecutor(max_workers = nthreads) as executor:
                     futures = []
                     for l in (set(np.unique(clear_lbl_img)) - set([0])):
-                        futures.apend(executor.submit(get_current_label, clear_lbl_img, l))
+                        futures.append(executor.submit(get_current_label, clear_lbl_img, l))
                     for future in concurrent.futures.as_completed(futures):
                         binary_image = future.result()    
                         vertices, faces, normals, values = marching_cubes(binary_image)

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -54,11 +54,11 @@ def tif_to_pc_directory(tif_directory, save_mesh, save_points, num_points):
 def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_points: int):
     acceptable_formats = [".tif", ".TIFF", ".TIF", ".png"]
     mesh_save_dir = os.path.join(save_dir, 'mesh')
+    point_cloud_save_dir = os.path.join(save_dir, 'point_cloud')
     Path(save_dir).mkdir(exist_ok = True)
     Path(mesh_save_dir).mkdir(exist_ok = True)
+
     if os.path.isdir(path):
-        mesh_data = []
-        points_data = []
         for fpath in tqdm(os.listdir(path)):     
             if any(fpath.endswith(f) for f in acceptable_formats):
                 lbl_img = imread(os.path.join(path, fpath))
@@ -73,12 +73,10 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
                     )
                     mesh_file = name + str(l) 
                     save_mesh_file = os.path.join(mesh_save_dir, mesh_file) + ".off"
+                    save_point_cloud_file = os.path.join(point_cloud_save_dir, mesh_file) + ".ply"
                     mesh_obj.export(save_mesh_file) 
                     data = read_off(os.path.join(mesh_save_dir, save_mesh_file))
                     points = sample_points(data=data, num=num_points).numpy()
-                    mesh_data.append(mesh_obj) 
-                    points_data.append(points)
-        
-        mesh_data = np.asarray(mesh_data)
-        points_data = np.asarray(points_data)
-        np.savez(os.path.join(save_dir, save_name), mesh=mesh_data, points=points_data)
+                    cloud = PyntCloud(pd.DataFrame(data=points, columns=["x", "y", "z"]))
+                    cloud.to_file(save_point_cloud_file)
+                    

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -62,9 +62,10 @@ def label_tif_to_pc_directory(path: str , save_dir: str, num_points: int):
     if os.path.isdir(path):
         for fpath in tqdm(os.listdir(path)):     
             if any(fpath.endswith(f) for f in acceptable_formats):
-                lbl_img = imread(os.path.join(path, fpath))
+                read_path = os.path.join(path, fpath)
+                lbl_img = imread(read_path)
                 clear_lbl_img = clear_border(lbl_img)
-                name = os.path.basename(os.path.splitext(path)[0])
+                name = os.path.basename(os.path.splitext(read_path)[0])
                 nthreads = os.cpu_count() - 1
 
                 with concurrent.futures.ThreadPoolExecutor(max_workers = nthreads) as executor:

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -57,7 +57,7 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
     point_cloud_save_dir = os.path.join(save_dir, 'point_cloud')
     Path(save_dir).mkdir(exist_ok = True)
     Path(mesh_save_dir).mkdir(exist_ok = True)
-
+    Path(point_cloud_save_dir).mkdir(exist_ok = True)
     if os.path.isdir(path):
         for fpath in tqdm(os.listdir(path)):     
             if any(fpath.endswith(f) for f in acceptable_formats):

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -63,9 +63,7 @@ def label_tif_to_pc_directory(path: str , save_dir: str, num_points: int):
         for fpath in tqdm(os.listdir(path)):     
             if any(fpath.endswith(f) for f in acceptable_formats):
                 lbl_img = imread(os.path.join(path, fpath))
-                print('image read')
                 clear_lbl_img = clear_border(lbl_img)
-                print('cleared borders')
                 name = os.path.basename(os.path.splitext(path)[0])
                 nthreads = os.cpu_count() - 1
 

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -51,7 +51,7 @@ def tif_to_pc_directory(tif_directory, save_mesh, save_points, num_points):
     mesh_to_pc(save_mesh, num_points, save_points)
 
 
-def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_points: int):
+def label_tif_to_pc_directory(path: str , save_dir: str, num_points: int):
     acceptable_formats = [".tif", ".TIFF", ".TIF", ".png"]
     mesh_save_dir = os.path.join(save_dir, 'mesh')
     point_cloud_save_dir = os.path.join(save_dir, 'point_cloud')

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -61,12 +61,12 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
                 lbl_img = imread(os.path.join(path, fpath))
                 for l in (set(np.unique(lbl_img)) - set([0])):
                     binary_image = lbl_img==l
-                    print(binary_image.shape)
+                    
                     vertices, faces, normals, values = marching_cubes(binary_image)
                     mesh_obj = trimesh.Trimesh(
                         vertices=vertices, faces=faces, process=False
                     )
-                    points = sample_points(data=mesh_obj, num=num_points).numpy()
+                    points = sample_points(data=mesh_obj.export(__file__), num=num_points).numpy()
                     mesh_data.append(mesh_obj) 
                     points_data.append(points)
         

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -70,8 +70,9 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
                         vertices=vertices, faces=faces, process=False
                     )
                     mesh_file = name + str(l) 
-                    mesh_obj.export(os.path.join(mesh_save_dir, mesh_file) + ".off") 
-                    data = read_off(os.path.join(mesh_save_dir, mesh_file))
+                    save_mesh_file = os.path.join(mesh_save_dir, mesh_file) + ".off"
+                    mesh_obj.export(save_mesh_file) 
+                    data = read_off(os.path.join(mesh_save_dir, save_mesh_file))
                     points = sample_points(data=data, num=num_points).numpy()
                     mesh_data.append(mesh_obj) 
                     points_data.append(points)

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -56,19 +56,20 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
     if os.path.isdir(path):
         mesh_data = []
         points_data = []
-        for fpath in os.listdir(path):     
+        for fpath in tqdm(os.listdir(path)):     
             if any(fpath.endswith(f) for f in acceptable_formats):
                 image = imread(os.path.join(path, fpath))
                 properties = regionprops(image)
                 binary_image = [prop.image for prop in properties]
-                vertices, faces, normals, values = marching_cubes(binary_image)
-                mesh_obj = trimesh.Trimesh(
-                    vertices=vertices, faces=faces, process=False
-                )
-                points = sample_points(data=mesh_obj, num=num_points).numpy()
-                mesh_data.append(mesh_obj) 
-                points_data.append(points)
+                for patch_image in binary_image:
+                    vertices, faces, normals, values = marching_cubes(patch_image)
+                    mesh_obj = trimesh.Trimesh(
+                        vertices=vertices, faces=faces, process=False
+                    )
+                    points = sample_points(data=mesh_obj, num=num_points).numpy()
+                    mesh_data.append(mesh_obj) 
+                    points_data.append(points)
         
         mesh_data = np.asarray(mesh_data)
         points_data = np.asarray(points_data)
-        np.savez(save_dir + save_name, mesh=mesh_data, points=points_data)
+        np.savez(os.path.join(save_dir, save_name), mesh=mesh_data, points=points_data)

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -52,13 +52,16 @@ def tif_to_pc_directory(tif_directory, save_mesh, save_points, num_points):
 
 def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_points: int):
     acceptable_formats = [".tif", ".TIFF", ".TIF", ".png"]
+    mesh_save_dir = os.path.join(save_dir, 'mesh')
     Path(save_dir).mkdir(exist_ok = True)
+    Path(mesh_save_dir).mkdir(exist_ok = True)
     if os.path.isdir(path):
         mesh_data = []
         points_data = []
         for fpath in tqdm(os.listdir(path)):     
             if any(fpath.endswith(f) for f in acceptable_formats):
                 lbl_img = imread(os.path.join(path, fpath))
+                name = os.path.basename(os.path.splitext(path)[0])
                 for l in (set(np.unique(lbl_img)) - set([0])):
                     binary_image = lbl_img==l
                     
@@ -66,7 +69,10 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
                     mesh_obj = trimesh.Trimesh(
                         vertices=vertices, faces=faces, process=False
                     )
-                    points = sample_points(data=read_off(mesh_obj.export(__file__+ ".off")), num=num_points).numpy()
+                    mesh_file = mesh_save_dir + name + str(l) 
+                    mesh_obj.export(mesh_file + ".off") 
+                    data = read_off(mesh_file)
+                    points = sample_points(data=data, num=num_points).numpy()
                     mesh_data.append(mesh_obj) 
                     points_data.append(points)
         

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -3,7 +3,8 @@ from pyntcloud import PyntCloud
 import pandas as pd
 from tifffile import imread
 import trimesh
-from skimage.measure import marching_cubes, regionprops
+from skimage.measure import marching_cubes
+from skimage.segmentation import clear_border
 from tqdm import tqdm
 from .util import create_dir_if_not_exist
 from pathlib import Path
@@ -61,9 +62,10 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
         for fpath in tqdm(os.listdir(path)):     
             if any(fpath.endswith(f) for f in acceptable_formats):
                 lbl_img = imread(os.path.join(path, fpath))
+                clear_lbl_img = clear_border(lbl_img)
                 name = os.path.basename(os.path.splitext(path)[0])
-                for l in (set(np.unique(lbl_img)) - set([0])):
-                    binary_image = lbl_img==l
+                for l in (set(np.unique(clear_lbl_img)) - set([0])):
+                    binary_image = clear_lbl_img==l
                     
                     vertices, faces, normals, values = marching_cubes(binary_image)
                     mesh_obj = trimesh.Trimesh(

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -10,6 +10,7 @@ from .util import create_dir_if_not_exist
 from pathlib import Path
 import os
 import numpy as np
+import concurrent
 
 def tif_to_mesh(tif_directory, save_directory):
     p = Path(tif_directory)
@@ -64,19 +65,29 @@ def label_tif_to_pc_directory(path: str , save_dir: str, num_points: int):
                 lbl_img = imread(os.path.join(path, fpath))
                 clear_lbl_img = clear_border(lbl_img)
                 name = os.path.basename(os.path.splitext(path)[0])
-                for l in (set(np.unique(clear_lbl_img)) - set([0])):
-                    binary_image = clear_lbl_img==l
+                nthreads = os.cpu_count()
+
+                with concurrent.futures.ThreadPoolExecutor(max_workers = nthreads) as executor:
+                    futures = []
+                    for l in (set(np.unique(clear_lbl_img)) - set([0])):
+                        futures.apend(executor.submit(get_current_label, clear_lbl_img, l))
+                    for future in concurrent.futures.as_completed(futures):
+                        binary_image = future.result()    
+                        vertices, faces, normals, values = marching_cubes(binary_image)
+                        mesh_obj = trimesh.Trimesh(
+                            vertices=vertices, faces=faces, process=False
+                        )
+                        mesh_file = name + str(l) 
+                        save_mesh_file = os.path.join(mesh_save_dir, mesh_file) + ".off"
+                        save_point_cloud_file = os.path.join(point_cloud_save_dir, mesh_file) + ".ply"
+                        mesh_obj.export(save_mesh_file) 
+                        data = read_off(os.path.join(mesh_save_dir, save_mesh_file))
+                        points = sample_points(data=data, num=num_points).numpy()
+                        cloud = PyntCloud(pd.DataFrame(data=points, columns=["x", "y", "z"]))
+                        cloud.to_file(save_point_cloud_file)
                     
-                    vertices, faces, normals, values = marching_cubes(binary_image)
-                    mesh_obj = trimesh.Trimesh(
-                        vertices=vertices, faces=faces, process=False
-                    )
-                    mesh_file = name + str(l) 
-                    save_mesh_file = os.path.join(mesh_save_dir, mesh_file) + ".off"
-                    save_point_cloud_file = os.path.join(point_cloud_save_dir, mesh_file) + ".ply"
-                    mesh_obj.export(save_mesh_file) 
-                    data = read_off(os.path.join(mesh_save_dir, save_mesh_file))
-                    points = sample_points(data=data, num=num_points).numpy()
-                    cloud = PyntCloud(pd.DataFrame(data=points, columns=["x", "y", "z"]))
-                    cloud.to_file(save_point_cloud_file)
-                    
+def get_current_label(clear_lbl_img, label):
+
+       binary_image = clear_lbl_img==label 
+
+       return binary_image                

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -58,13 +58,10 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
         points_data = []
         for fpath in tqdm(os.listdir(path)):     
             if any(fpath.endswith(f) for f in acceptable_formats):
-                image = imread(os.path.join(path, fpath))
-                print(image.shape)
-                properties = regionprops(image)
-                binary_image = [prop.image for prop in properties]
-                print(len(binary_image), np.asarray(binary_image).shape)
-                for i in len(binary_image):
-                    vertices, faces, normals, values = marching_cubes(binary_image[i,:])
+                lbl_img = imread(os.path.join(path, fpath))
+                for l in (set(np.unique(lbl_img)) - set([0])):
+                    binary_image = lbl_img==l
+                    vertices, faces, normals, values = marching_cubes(binary_image)
                     mesh_obj = trimesh.Trimesh(
                         vertices=vertices, faces=faces, process=False
                     )

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -63,7 +63,9 @@ def label_tif_to_pc_directory(path: str , save_dir: str, num_points: int):
         for fpath in tqdm(os.listdir(path)):     
             if any(fpath.endswith(f) for f in acceptable_formats):
                 lbl_img = imread(os.path.join(path, fpath))
+                print('image read')
                 clear_lbl_img = clear_border(lbl_img)
+                print('cleared borders')
                 name = os.path.basename(os.path.splitext(path)[0])
                 nthreads = os.cpu_count()
 

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -72,12 +72,12 @@ def label_tif_to_pc_directory(path: str , save_dir: str, num_points: int):
                     for l in tqdm(set(np.unique(clear_lbl_img)) - set([0])):
                         futures.append(executor.submit(get_current_label, clear_lbl_img, l))
                     for future in concurrent.futures.as_completed(futures):
-                        binary_image = future.result()    
+                        binary_image, label = future.result()    
                         vertices, faces, normals, values = marching_cubes(binary_image)
                         mesh_obj = trimesh.Trimesh(
                             vertices=vertices, faces=faces, process=False
                         )
-                        mesh_file = name + str(l) 
+                        mesh_file = name + str(label) 
                         save_mesh_file = os.path.join(mesh_save_dir, mesh_file) + ".off"
                         save_point_cloud_file = os.path.join(point_cloud_save_dir, mesh_file) + ".ply"
                         mesh_obj.export(save_mesh_file) 
@@ -90,4 +90,4 @@ def get_current_label(clear_lbl_img, label):
 
        binary_image = clear_lbl_img==label 
 
-       return binary_image                
+       return binary_image, label                 

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -62,6 +62,7 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
                 print(image.shape)
                 properties = regionprops(image)
                 binary_image = [prop.image for prop in properties]
+                print(len(binary_image), np.asarray(binary_image).shape)
                 for i in len(binary_image):
                     vertices, faces, normals, values = marching_cubes(binary_image[i,:])
                     mesh_obj = trimesh.Trimesh(

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -61,6 +61,7 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
                 lbl_img = imread(os.path.join(path, fpath))
                 for l in (set(np.unique(lbl_img)) - set([0])):
                     binary_image = lbl_img==l
+                    print(binary_image.shape)
                     vertices, faces, normals, values = marching_cubes(binary_image)
                     mesh_obj = trimesh.Trimesh(
                         vertices=vertices, faces=faces, process=False

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -66,7 +66,7 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
                     mesh_obj = trimesh.Trimesh(
                         vertices=vertices, faces=faces, process=False
                     )
-                    points = sample_points(data=mesh_obj.export(__file__), num=num_points).numpy()
+                    points = sample_points(data=mesh_obj.export(__file__+ ".off"), num=num_points).numpy()
                     mesh_data.append(mesh_obj) 
                     points_data.append(points)
         

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -66,7 +66,7 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
                     mesh_obj = trimesh.Trimesh(
                         vertices=vertices, faces=faces, process=False
                     )
-                    points = sample_points(data=mesh_obj.export(__file__+ ".off"), num=num_points).numpy()
+                    points = sample_points(data=read_off(mesh_obj.export(__file__+ ".off")), num=num_points).numpy()
                     mesh_data.append(mesh_obj) 
                     points_data.append(points)
         

--- a/cellshape_helper/conversions.py
+++ b/cellshape_helper/conversions.py
@@ -59,10 +59,11 @@ def label_tif_to_pc_directory(path: str , save_dir: str, save_name: str, num_poi
         for fpath in tqdm(os.listdir(path)):     
             if any(fpath.endswith(f) for f in acceptable_formats):
                 image = imread(os.path.join(path, fpath))
+                print(image.shape)
                 properties = regionprops(image)
                 binary_image = [prop.image for prop in properties]
-                for patch_image in binary_image:
-                    vertices, faces, normals, values = marching_cubes(patch_image)
+                for i in len(binary_image):
+                    vertices, faces, normals, values = marching_cubes(binary_image[i,:])
                     mesh_obj = trimesh.Trimesh(
                         vertices=vertices, faces=faces, process=False
                     )


### PR DESCRIPTION
# Description

Include a function that takes in directory of 3D label images and for each label writes a point cloud and mesh object for each labelled object. The border label objects are ignored.

Fixes # [(issue)](https://github.com/Sentinal4D/cellshape-helper/issues/11)

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Tested on a real dataset that contains patches of XYZ labelled images.





# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
